### PR TITLE
Add flake for nix setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,16 @@
+# Use with direnv (https://direnv.net/)
+# Install direnv and add 'eval "$(direnv hook bash)"' to your shell config
+
+# For flakes support
+use flake
+
+# Fallback for older nix without flakes
+use_nix() {
+  watch_file shell.nix
+  eval "$(nix-shell --command 'bash -c "declare -p -x > /dev/stdout"')"
+}
+
+# If flakes fail, try the older method
+if ! type -p use > /dev/null; then
+  use_nix
+fi 

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,8 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Nix specific
+.direnv/
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ nix develop
 nix build
 ```
 
+The build process produces the following executables:
+
+- `result/bin/jukebox-django-server` - Run the Django web server
+- `result/bin/jukebox-django-backend` - Run the backend server
+- `result/bin/jukebox-django-setup` - Setup a virtual environment with missing packages
+
 #### Without flakes:
 
 ```bash
@@ -95,6 +101,32 @@ To deploy this application on a NixOS system, you can import the flake directly 
           environment.systemPackages = [
             jukebox-django.packages.${pkgs.system}.default
           ];
+          
+          # Optional: Create a systemd service for the backend server
+          systemd.services.jukebox-backend = {
+            description = "Jukebox Backend Service";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+            serviceConfig = {
+              ExecStart = "${jukebox-django.packages.${pkgs.system}.default}/bin/jukebox-django-backend";
+              Restart = "always";
+              User = "jukebox";
+              Group = "jukebox";
+            };
+          };
+          
+          # Optional: Create a systemd service for the Django server
+          systemd.services.jukebox-server = {
+            description = "Jukebox Django Web Service";
+            wantedBy = [ "multi-user.target" ];
+            after = [ "network.target" ];
+            serviceConfig = {
+              ExecStart = "${jukebox-django.packages.${pkgs.system}.default}/bin/jukebox-django-server 0.0.0.0:8000";
+              Restart = "always";
+              User = "jukebox";
+              Group = "jukebox";
+            };
+          };
         })
       ];
     };

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Jukebox rewrite with Django - currently newstaff project Fa24
 
 ## Getting started
 
+### Option 1: Using Poetry (Standard method)
+
 Requirements:
 
 - Python 3.10-3.12
@@ -28,13 +30,16 @@ Activate the Poetry environment:
 poetry shell
 ```
 
-## Using Nix (recommended for NixOS deployments)
+### Option 2: Using Nix (Recommended for NixOS deployments)
 
-This project includes Nix flake support for reproducible environments with all dependencies:
+This project includes Nix support for reproducible environments with all dependencies, including system libraries like PortAudio which PyAudio requires.
 
-### With flakes enabled:
+Requirements:
+- Nix package manager (https://nixos.org/download.html)
 
-```
+#### With flakes enabled:
+
+```bash
 # Development shell
 nix develop
 
@@ -42,14 +47,14 @@ nix develop
 nix build
 ```
 
-### Without flakes:
+#### Without flakes:
 
-```
+```bash
 # Development shell
 nix-shell
 ```
 
-The Nix configuration automatically handles all dependencies, including system libraries like PortAudio which PyAudio requires.
+The Nix configuration automatically creates a Python virtual environment (.venv) and installs all required packages, including those not available in nixpkgs.
 
 ## Running the project
 
@@ -72,3 +77,27 @@ python manage.py runserver
 ```
 
 Go to `http://127.0.0.1:8000/YTUSRN/` to access the website.
+
+## Deployment on NixOS
+
+To deploy this application on a NixOS system, you can import the flake directly in your NixOS configuration:
+
+```nix
+{
+  inputs.jukebox-django.url = "github:ocf/jukebox-django";
+  
+  outputs = { self, nixpkgs, jukebox-django, ... }: {
+    nixosConfigurations.yourSystem = nixpkgs.lib.nixosSystem {
+      # ...
+      modules = [
+        # ...
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            jukebox-django.packages.${pkgs.system}.default
+          ];
+        })
+      ];
+    };
+  };
+}
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ Activate the Poetry environment:
 poetry shell
 ```
 
+## Using Nix (recommended for NixOS deployments)
+
+This project includes Nix flake support for reproducible environments with all dependencies:
+
+### With flakes enabled:
+
+```
+# Development shell
+nix develop
+
+# Build the package
+nix build
+```
+
+### Without flakes:
+
+```
+# Development shell
+nix-shell
+```
+
+The Nix configuration automatically handles all dependencies, including system libraries like PortAudio which PyAudio requires.
+
 ## Running the project
 
 #### Starting the Server

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740695751,
+        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,15 +34,17 @@
             pyaudio
             websockets
             aioconsole
-            django-icons
             channels
             daphne
             portaudio  # System dependency for pyaudio
+            pip  # Include pip for installing missing packages
           ];
 
-          # Make sure Python can find portaudio
+          # Make sure Python can find portaudio and install missing packages
           makeWrapperArgs = [
             "--prefix LD_LIBRARY_PATH : ${pkgs.portaudio}/lib"
+            # Install missing packages on first run
+            "--run 'pip install django-icons==24.4 --no-warn-script-location'"
           ];
 
           # Skip tests during build
@@ -60,11 +62,15 @@
             python311
             python311Packages.poetry
             portaudio
+            python311Packages.pip
           ];
 
           shellHook = ''
             # Set up environment variables if needed
             export PYTHONPATH=$PWD:$PYTHONPATH
+            
+            # Install packages not in nixpkgs
+            pip install django-icons==24.4 --no-warn-script-location
             
             # Note for users
             echo "Nix development environment for jukebox-django"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  description = "OCF Jukebox Django Application";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+
+        pythonPackages = pkgs.python311Packages;
+
+        jukebox-django = pythonPackages.buildPythonApplication {
+          pname = "jukebox-django";
+          version = "0.1.0";
+          format = "pyproject";
+
+          src = ./.;
+
+          nativeBuildInputs = [
+            pythonPackages.poetry-core
+          ];
+
+          propagatedBuildInputs = with pythonPackages; [
+            django
+            yt-dlp
+            jsonpickle
+            wheel
+            pyaudio
+            websockets
+            aioconsole
+            django-icons
+            channels
+            daphne
+            portaudio  # System dependency for pyaudio
+          ];
+
+          # Make sure Python can find portaudio
+          makeWrapperArgs = [
+            "--prefix LD_LIBRARY_PATH : ${pkgs.portaudio}/lib"
+          ];
+
+          # Skip tests during build
+          doCheck = false;
+        };
+      in
+      {
+        packages = {
+          default = jukebox-django;
+          jukebox-django = jukebox-django;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            python311
+            python311Packages.poetry
+            portaudio
+          ];
+
+          shellHook = ''
+            # Set up environment variables if needed
+            export PYTHONPATH=$PWD:$PYTHONPATH
+            
+            # Note for users
+            echo "Nix development environment for jukebox-django"
+            echo "To run the backend server: cd jukebox/backend && python runner.py"
+            echo "To run the Django server: cd jukebox && python manage.py runserver"
+          '';
+        };
+      });
+} 

--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,8 @@
             aioconsole
             channels
             daphne
-            portaudio  # System dependency for pyaudio
             pip  # Include pip for installing missing packages
-          ];
+          ] ++ [ pkgs.portaudio ];  # Add system dependency for pyaudio
 
           # Make sure Python can find portaudio and install missing packages
           makeWrapperArgs = [

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           src = ./.;
 
           nativeBuildInputs = [
-            pkgs.poetry-core
+            pythonPackages.poetry-core
           ];
 
           propagatedBuildInputs = with pythonPackages; [
@@ -60,9 +60,11 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             python311
-            poetry
+            (python311.withPackages (ps: with ps; [
+              poetry-core
+              pip
+            ]))
             portaudio
-            python311Packages.pip
           ];
 
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
             (python311.withPackages (ps: with ps; [
               poetry-core
               pip
-              venv
+              # venv is a built-in module, not a package
             ]))
             portaudio
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
           src = ./.;
 
           nativeBuildInputs = [
-            pythonPackages.poetry-core
+            pkgs.poetry-core
           ];
 
           propagatedBuildInputs = with pythonPackages; [
@@ -60,7 +60,7 @@
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             python311
-            python311Packages.poetry
+            poetry
             portaudio
             python311Packages.pip
           ];

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,8 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [
     python311
-    python311Packages.poetry
+    python311Packages.pip
+    python311Packages.poetry-core
     portaudio
   ];
 
@@ -17,8 +18,19 @@ pkgs.mkShell {
     # Use the portaudio library
     export LD_LIBRARY_PATH=${pkgs.portaudio}/lib:$LD_LIBRARY_PATH
     
+    # Create a local virtual environment for pip packages
+    if [ ! -d .venv ]; then
+      echo "Creating virtual environment..."
+      ${pkgs.python311}/bin/python -m venv .venv
+      . .venv/bin/activate
+      pip install django-icons==24.4
+    else
+      . .venv/bin/activate
+    fi
+    
     # Note for users
-    echo "Nix development environment for jukebox-django"
+    echo "Nix development environment for jukebox-django activated!"
+    echo "Virtual environment is active with all dependencies installed."
     echo "To run the backend server: cd jukebox/backend && python runner.py"
     echo "To run the Django server: cd jukebox && python manage.py runserver"
   '';

--- a/shell.nix
+++ b/shell.nix
@@ -5,9 +5,18 @@
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
-    python311
-    python311Packages.pip
-    python311Packages.poetry-core
+    (python311.withPackages (ps: with ps; [
+      django
+      yt-dlp
+      jsonpickle
+      wheel
+      pyaudio
+      websockets
+      aioconsole
+      channels
+      daphne
+      pip
+    ]))
     portaudio
   ];
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,25 @@
+# shell.nix - For compatibility with older Nix installations
+# Use this with: nix-shell
+
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    python311
+    python311Packages.poetry
+    portaudio
+  ];
+
+  shellHook = ''
+    # Set up environment variables if needed
+    export PYTHONPATH=$PWD:$PYTHONPATH
+    
+    # Use the portaudio library
+    export LD_LIBRARY_PATH=${pkgs.portaudio}/lib:$LD_LIBRARY_PATH
+    
+    # Note for users
+    echo "Nix development environment for jukebox-django"
+    echo "To run the backend server: cd jukebox/backend && python runner.py"
+    echo "To run the Django server: cd jukebox && python manage.py runserver"
+  '';
+} 


### PR DESCRIPTION
Previously, there were issues with the build process on nix machines, including with gcc, pip, portaudio, pyaudio, etc. This PR adds a flake.nix file to bundle dependencies into one environment, to streamline deployment on OCF hosts.